### PR TITLE
fix: terraform diff workflow path based filter

### DIFF
--- a/.github/workflows/terraform-diff.yml
+++ b/.github/workflows/terraform-diff.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - master
-    paths:
-      - 'examples/complete/**'
 
 jobs:
   complete-example:

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   complete-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/stf-checks.yml@v2
+    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@v2
     with:
       working_directory: './examples/complete/'
       provider: none

--- a/.github/workflows/tf-checks.yml
+++ b/.github/workflows/tf-checks.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   complete-example:
-    uses: clouddrove/github-shared-workflows/.github/workflows/tf-checks.yml@v2
+    uses: clouddrove/github-shared-workflows/.github/workflows/smurf-tf-checks.yml@v2
     with:
       working_directory: './examples/complete/'
       provider: none


### PR DESCRIPTION
## Description

- Removed the path based filter from the terraform diff workflow

<!--
🎉 Thank you for your contribution!

Please provide a brief summary of the changes in this pull request, including:
- A short description of what the PR does
- The reason or motivation for the change
- Relevant issue references, e.g., Fixes #123 or Closes #456
- Any context that helps reviewers understand the impact or use case
- Dependencies introduced, if any
- Screenshots or logs, if applicable (e.g., UI changes or test outputs)
-->

Fixes # 

Closes # 

---

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Feature
- [ ] Feature (Breaking Change)
- [x] Fix
- [ ] Fix (Breaking Change)
- [ ] CI/CD
- [ ] Documentation
- [ ] Other (please specify):

---

## Checklist

- [ ] I have reviewed open pull requests to avoid duplication of work
- [ ] All relevant pipelines or checks pass successfully
- [ ] I have added or updated documentation if applicable
